### PR TITLE
Update MetaDB message lib version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <spring.boot.version>2.3.3.RELEASE</spring.boot.version>
     <!-- metadb messaging and shared entities dependency versions -->
     <cmo_metadb_messaging_java.group>com.github.mskcc</cmo_metadb_messaging_java.group>
-    <cmo_metadb_messaging_java.version>e01088f714e7f77e2187e1ed5943789a2cacb415</cmo_metadb_messaging_java.version>
+    <cmo_metadb_messaging_java.version>1.1.6.RELEASE</cmo_metadb_messaging_java.version>
     <!-- metadb common centralized config properties -->
     <cmo_metadb_common.groupId>com.github.mskcc</cmo_metadb_common.groupId>
     <cmo_metadb_common.version>1.1.7.RELEASE</cmo_metadb_common.version>


### PR DESCRIPTION
Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>

Briefly describe changes proposed in this pull request:
- Updates MetaDB messaging lib version to 1.1.6.RELEASE
